### PR TITLE
Update amplify.yml

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -9,7 +9,7 @@ frontend:
   phases:
     build:
       commands:
-        - npm install -g @angular/cli
+        - npm install -g @angular/cli@17.3.0
         - ng version
         - ng build --configuration=production
   artifacts:


### PR DESCRIPTION
NPM install for the angular cli currently targets version 18 which is not supported by the NPM build version. Targeting 17 will prevent build errors until the project is fully updated to 18

*Issue #6 :*

added an @ target for the angular version until the repo can be updated to 18


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
