### PR TITLE
remove global install of @angular/cli in amplify.yml

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -9,11 +9,10 @@ frontend:
   phases:
     preBuild:
       commands:
-        - npm install -g @angular/cli@17.3.11
-        - ng version
+        - npx ng version
     build:
       commands:
-        - ng build --configuration=production
+        - npx ng build --configuration=production
   artifacts:
     baseDirectory: dist/amplify-angular-template/browser
     files:

--- a/amplify.yml
+++ b/amplify.yml
@@ -7,10 +7,12 @@ backend:
         - npx ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
 frontend:
   phases:
+    preBuild:
+      commands:
+        - npm install -g @angular/cli@17.3.11
+        - ng version
     build:
       commands:
-        - npm install -g @angular/cli
-        - ng version
         - ng build --configuration=production
   artifacts:
     baseDirectory: dist/amplify-angular-template/browser


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/amplify-angular-template/issues/6
https://github.com/aws-amplify/amplify-backend/issues/2225
https://github.com/aws-amplify/docs/issues/8086

*Description of changes:*
This PR pins the patch version for `@angular/cli` package to `v17.3.11` to match that of the app's `package.json` file. 

Starting `v18.0.x` and above, the min Node version required is `v18.19.1` and Amplify's default build image (AL2023) out-of-the-box comes with Node version `v18.18.2`. Although it does [support](https://aws.amazon.com/blogs/mobile/amazon-linux-2023-hosting/) Node v20, it's better to instead pin the package version to `17.3.x` to match the app configuration.

Angular version compatibility: https://angular.dev/reference/versions#actively-supported-versions

Manual testing was done by deploying the starter template with these changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
