### PR TITLE
fix: add polyfills to resolve 'global is not defined' error

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -17,6 +17,7 @@
             "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": [
+              "src/polyfills.ts",
               "zone.js"
             ],
             "tsConfig": "tsconfig.app.json",
@@ -75,6 +76,7 @@
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
             "polyfills": [
+              "src/polyfills.ts",
               "zone.js",
               "zone.js/testing"
             ],

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,0 +1,4 @@
+(window as any).global = window;
+(window as any).process = {
+  env: { DEBUG: undefined },
+};

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -6,7 +6,8 @@
     "types": []
   },
   "files": [
-    "src/main.ts"
+    "src/main.ts",
+    "src/polyfills.ts"
   ],
   "include": [
     "src/**/*.d.ts"


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-amplify/amplify-js/issues/14494

*Description of changes:*

Adds browser polyfills to resolve the Uncaught ReferenceError: global is not defined error that occurs when deploying this project to browser environments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
